### PR TITLE
Added Library Dependencies for Example Applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore PlatformID and Visual Code files that aren't needed
+# Ignore PlatformIO and Visual Code files that aren't needed
 .pio
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore PlatformID and Visual Code files that aren't needed
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+
+# Ignore Finder files on the Mac
+.DS_Store
+

--- a/Release/Source/Examples/AmbaSat-LoRa/platformio.ini
+++ b/Release/Source/Examples/AmbaSat-LoRa/platformio.ini
@@ -14,3 +14,5 @@ board = AmbaSat-1
 framework = arduino
 monitor_speed = 9600 
 upload_speed = 9600  
+lib_deps =
+    https://github.com/PaulStoffregen/RadioHead.git

--- a/Release/Source/Examples/AmbaSat-TTN/platformio.ini
+++ b/Release/Source/Examples/AmbaSat-TTN/platformio.ini
@@ -17,6 +17,10 @@
 platform = atmelavr
 board = AmbaSat-1
 framework = arduino
+lib_deps =
+    Low-Power
+    I2C-Sensor-Lib iLib
+    https://github.com/matthijskooijman/arduino-lmic.git
 
 ; [env:nanoatmega328]
 ; platform = atmelavr


### PR DESCRIPTION
Some of the example applications do not have library dependencies indicated in their respective `platform.ini` file. I suspect the original developer had this libraries installed globally. This PR adds the dependencies at the project level so that everyone can build them successfully.

Also added a repository level `.gitignore` mostly to added the Mac-specific ignore line.